### PR TITLE
Use `vcsh list`, add repos to all completions, and update install paths in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # vcsh_bash_completion
-Place vcsh file in /etc/bash_completion.d/
+## Installation
+Place vcsh file in: '/usr/share/bash-completion/completions/'
+or in the legacy directory: '/etc/bash_completion.d/'

--- a/vcsh
+++ b/vcsh
@@ -22,7 +22,7 @@ _vcsh()
 		;;      
     esac
    
-   COMPREPLY=($(compgen -W "${opts}" -- ${cur}) )
+   COMPREPLY=($(compgen -W "${opts} $(vcsh list)" -- ${cur}) )
    return 0
             
 }


### PR DESCRIPTION
Firstly, use `vcsh list` instead of parsing the repos dir. This allows for situations where vcsh is configured to keep the repos dir somewhere other than ~/.config/vcsh/repo.d/ 

Next, update the README to reflect appropriate paths. /etc/bash_completion.d/ is a legacy path, and is only kept for backwards compatibility. A more appropriate location is /usr/share/bash-completion/completions/

Finally, Include repo names for all completions. vcsh provides for a way to run git commands directly with `vcsh reponame gitcommand`, so it makes sense to include repo names in all completions.